### PR TITLE
fix: Properly close `adb` and `rclone` on exit

### DIFF
--- a/main.js
+++ b/main.js
@@ -538,6 +538,11 @@ async function startApp() {
       app.quit();
     }
   });
+
+  app.on("will-quit", async () => {
+    console.log("will-quit");
+    await tools.destroy();
+  });
 }
 
 startApp();


### PR DESCRIPTION
Fixes #34

Cleanly closes `adb` and `rclone` connections when the application exits, ensuring resources are freed and preventing potential issues. This addresses a previous oversight where these connections weren't properly closed, potentially leading to resource leaks or unexpected behavior.

Even though we free up the adb connection we don't close the server because other programs may be using the connection.